### PR TITLE
Only dequeue if connection still exists

### DIFF
--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -9,13 +9,26 @@ import java.io.*
 import java.util.*
 import java.util.concurrent.*
 
+fun getFirstOpenConnection(
+    queue: Queue<Pair<GameConnection, CompletableFuture<Pair<Game, Player>>>>,
+): Pair<GameConnection, CompletableFuture<Pair<Game, Player>>>? {
+    while (queue.count() >= 1) {
+        val (c, gf) = queue.remove()
+        if (c.isOpen) {
+            return Pair(c, gf)
+        }
+    }
+    return null
+}
+
 fun main() {
     val db = GameDatabase()
     if (!File("data/data.db").exists()) {
         db.createTables()
     }
 
-    val playerQueue: Queue<Pair<GameConnection, CompletableFuture<Pair<Game, Player>>>> = LinkedList()
+    val playerQueue: Queue<Pair<GameConnection, CompletableFuture<Pair<Game, Player>>>> =
+        LinkedList()
 
     println("Listening for clients...")
     embeddedServer(Netty, port = 9933) {
@@ -29,8 +42,14 @@ fun main() {
                 playerQueue.add(Pair(connection, gameFuture))
 
                 while (playerQueue.count() >= 2) {
-                    val (p1c, p1gf) = playerQueue.remove()
-                    val (p2c, p2gf) = playerQueue.remove()
+                    val (p1c, p1gf) = getFirstOpenConnection(playerQueue) ?: break
+                    val p2 = getFirstOpenConnection(playerQueue)
+                    if (p2 == null) {
+                        playerQueue.add(Pair(p1c, p1gf))
+                        break
+                    }
+                    val (p2c, p2gf) = p2
+
                     val newGame = Game(p1c, p2c, db)
                     println("Starting game ${newGame.id}")
                     p1gf.complete(Pair(newGame, Player.Player1))

--- a/src/main/kotlin/objects/GameConnection.kt
+++ b/src/main/kotlin/objects/GameConnection.kt
@@ -69,30 +69,27 @@ class GameConnection(socket: DefaultWebSocketServerSession) {
         }
     }
 
-    var isOpen = true
-        private set
+    val isOpen: Boolean
+        get() = clientSocket.outgoing.isClosedForSend
 
     suspend fun receivePacket(): Packet? {
-        val text = try {
-            (clientSocket.incoming.receive() as Frame.Text).readText()
-        } catch (e: SocketException) {
-            isOpen = false
-            return null
-        } catch (e: EOFException) {
-            isOpen = false
-            return null
-        } catch (e: ClosedReceiveChannelException) {
-            isOpen = false
-            return null
-        } catch (e: Exception) {
-            isOpen = false
-            e.printStackTrace()
-            return null
-        }
+        val text =
+            try {
+                (clientSocket.incoming.receive() as Frame.Text).readText()
+            } catch (e: SocketException) {
+                return null
+            } catch (e: EOFException) {
+                return null
+            } catch (e: ClosedReceiveChannelException) {
+                return null
+            } catch (e: Exception) {
+                e.printStackTrace()
+                return null
+            }
 
         return try {
             val packet = Json.decodeFromString<Packet>(text)
-            println("Received '${packet}'")
+            println("Received '$packet'")
             packet
         } catch (e: IllegalArgumentException) {
             e.printStackTrace()
@@ -118,6 +115,5 @@ class GameConnection(socket: DefaultWebSocketServerSession) {
     suspend fun close() {
         println("closing connection")
         clientSocket.close(CloseReason(CloseReason.Codes.NORMAL, "Bye"))
-        isOpen = false
     }
 }

--- a/src/main/kotlin/objects/GameConnection.kt
+++ b/src/main/kotlin/objects/GameConnection.kt
@@ -70,7 +70,7 @@ class GameConnection(socket: DefaultWebSocketServerSession) {
     }
 
     val isOpen: Boolean
-        get() = clientSocket.outgoing.isClosedForSend
+        get() = !clientSocket.outgoing.isClosedForSend
 
     suspend fun receivePacket(): Packet? {
         val text =


### PR DESCRIPTION
(Let me know if there are more idiomatic ways to achieve what I did here)

This is a bug fix for the following bug reproduction.

Bug:
1. Run the server
2. Client enters matchmaking
3. Quit client with ALT+F4
4. Run new client
5. New client enters matchmaking

Unexpected behavior: a game starts. 
Expected behavior: game does not start

Ideally, if a web socket connection has already been closed it should be removed from the queue.