### PR TITLE
Passive Refractor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
-    kotlin("jvm") version "2.1.0"
-    kotlin("plugin.serialization") version "2.1.0"
+    kotlin("jvm") version "2.0.20"
+    kotlin("plugin.serialization") version "2.0.20"
 
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 }
@@ -18,9 +18,9 @@ repositories {
 dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.7.3")
 
     implementation("org.jetbrains.exposed", "exposed-core", exposedVersion)
     implementation("org.jetbrains.exposed", "exposed-dao", exposedVersion)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
-    kotlin("jvm") version "2.0.20"
-    kotlin("plugin.serialization") version "2.0.20"
+    kotlin("jvm") version "2.1.0"
+    kotlin("plugin.serialization") version "2.1.0"
 
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 }
@@ -18,9 +18,9 @@ repositories {
 dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.8.0")
 
     implementation("org.jetbrains.exposed", "exposed-core", exposedVersion)
     implementation("org.jetbrains.exposed", "exposed-dao", exposedVersion)

--- a/src/main/kotlin/objects/packets/objects/CardStats.kt
+++ b/src/main/kotlin/objects/packets/objects/CardStats.kt
@@ -31,7 +31,7 @@ class CardStats(
     @Required val tactics: Array<Tactic>,
     @Required val card_type: CardType,
     @Required val ability: Ability,
-    @Required val passive: Passive = Passive()
+    @Required val passive: Passive = Passive(),
 ) {
     init {
         assert(summoning_cost in 0..10)
@@ -91,7 +91,7 @@ class CardStats(
                         arrayOf<Tactic>(),
                         CardType.DECK_MASTER,
                         Ability(AbilityEffect.ADD_HP, 3, AbilityRange.ALLY_CARD, 4),
-                        Passive(PassiveEffectType.BUFF_ADJACENT, intArrayOf(1, 1), 2)
+                        Passive(PassiveEffectType.BUFF_ADJACENT, intArrayOf(1, 1), 2),
                     ),
                 3 to
                     CardStats(
@@ -103,7 +103,7 @@ class CardStats(
                         arrayOf<Tactic>(),
                         CardType.CREATURE,
                         Ability(AbilityEffect.SEAL, 1, AbilityRange.ENEMY_CARD, 0),
-                        Passive()
+                        Passive(),
                     ),
                 4 to
                     CardStats(

--- a/src/main/kotlin/objects/packets/objects/CardStats.kt
+++ b/src/main/kotlin/objects/packets/objects/CardStats.kt
@@ -25,13 +25,13 @@ enum class CardType {
 class CardStats(
     @Required val name: String,
     @Required var graphics: String?,
-    @Required val max_hp: Int,
-    @Required val base_atk: Int,
     @Required var summoning_cost: Int,
+    @Required val base_atk: Int,
+    @Required val max_hp: Int,
     @Required val tactics: Array<Tactic>,
     @Required val card_type: CardType,
     @Required val ability: Ability,
-    @Required val has_summoning_sickness: Boolean,
+    @Required val passive: Passive = Passive()
 ) {
     init {
         assert(summoning_cost in 0..10)
@@ -55,7 +55,6 @@ class CardStats(
             return name.replace(" ", "_").replace("'", "_").lowercase()
         }
 
-        // TODO: maybe move this out of here since it isn't networking related
         val cardIDMapping: HashMap<Int, CardStats> =
             hashMapOf(
                 0 to
@@ -65,58 +64,58 @@ class CardStats(
                         2,
                         2,
                         2,
-                        arrayOf<Tactic>(),
+                        arrayOf<Tactic>(Tactic.REACH),
                         CardType.CREATURE,
                         Ability(),
-                        true,
+                        Passive(),
                     ),
                 1 to
                     CardStats(
                         "Filipino Boy",
                         null,
-                        3,
-                        3,
-                        5,
+                        4,
+                        2,
+                        2,
                         arrayOf<Tactic>(Tactic.REACH),
                         CardType.CREATURE,
                         Ability(),
-                        true,
+                        Passive(PassiveEffectType.DRAW_ON_DESTRUCTION),
                     ),
                 2 to
                     CardStats(
                         "Angel Neuro",
                         null,
-                        24,
-                        2,
                         0,
+                        2,
+                        24,
                         arrayOf<Tactic>(),
                         CardType.DECK_MASTER,
                         Ability(AbilityEffect.ADD_HP, 3, AbilityRange.ALLY_CARD, 4),
-                        true,
+                        Passive(PassiveEffectType.BUFF_ADJACENT, 1, 1)
                     ),
                 3 to
                     CardStats(
                         "That streaming site she uses",
                         null,
+                        4,
+                        4,
                         3,
-                        4,
-                        4,
                         arrayOf<Tactic>(),
                         CardType.CREATURE,
                         Ability(AbilityEffect.SEAL, 1, AbilityRange.ENEMY_CARD, 0),
-                        true,
+                        Passive()
                     ),
                 4 to
                     CardStats(
                         "10 Tins Cans 1 Stream",
                         null,
+                        5,
                         0,
                         0,
-                        4,
                         arrayOf<Tactic>(),
                         CardType.MAGIC,
-                        Ability(AbilityEffect.ATTACK, 5, AbilityRange.ENEMY_CARD, 0),
-                        true,
+                        Ability(AbilityEffect.ATTACK, 5, AbilityRange.ENEMY_ROW, 0),
+                        Passive(),
                     ),
             )
 

--- a/src/main/kotlin/objects/packets/objects/CardStats.kt
+++ b/src/main/kotlin/objects/packets/objects/CardStats.kt
@@ -91,7 +91,7 @@ class CardStats(
                         arrayOf<Tactic>(),
                         CardType.DECK_MASTER,
                         Ability(AbilityEffect.ADD_HP, 3, AbilityRange.ALLY_CARD, 4),
-                        Passive(PassiveEffectType.BUFF_ADJACENT, 1, 1)
+                        Passive(PassiveEffectType.BUFF_ADJACENT, intArrayOf(1, 1), 2)
                     ),
                 3 to
                     CardStats(

--- a/src/main/kotlin/objects/packets/objects/Passive.kt
+++ b/src/main/kotlin/objects/packets/objects/Passive.kt
@@ -14,9 +14,10 @@ enum class PassiveEffectType {
 @Serializable
 data class Passive(
     @Required var effect: PassiveEffectType = PassiveEffectType.NONE,
-    @Required var valueX: Int = 0,
-    @Required var valueY: Int = 0,
-)
-
-
-
+    @Required var values: IntArray = IntArray(0),
+    @Required var values_size: Int = 0
+) {
+    init {
+        require(values.size == values_size)
+    }
+}

--- a/src/main/kotlin/objects/packets/objects/Passive.kt
+++ b/src/main/kotlin/objects/packets/objects/Passive.kt
@@ -15,9 +15,29 @@ enum class PassiveEffectType {
 data class Passive(
     @Required var effect: PassiveEffectType = PassiveEffectType.NONE,
     @Required var values: IntArray = IntArray(0),
-    @Required var values_size: Int = 0
+    @Required var valuesSize: Int = 0
 ) {
     init {
-        require(values.size == values_size)
+        require(values.size == valuesSize)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Passive
+
+        if (effect != other.effect) return false
+        if (!values.contentEquals(other.values)) return false
+        if (valuesSize != other.valuesSize) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = effect.hashCode()
+        result = 31 * result + values.contentHashCode()
+        result = 31 * result + valuesSize
+        return result
     }
 }

--- a/src/main/kotlin/objects/packets/objects/Passive.kt
+++ b/src/main/kotlin/objects/packets/objects/Passive.kt
@@ -15,7 +15,7 @@ enum class PassiveEffectType {
 data class Passive(
     @Required var effect: PassiveEffectType = PassiveEffectType.NONE,
     @Required var values: IntArray = IntArray(0),
-    @Required var valuesSize: Int = 0
+    @Required var valuesSize: Int = 0,
 ) {
     init {
         require(values.size == valuesSize)

--- a/src/main/kotlin/objects/packets/objects/Passive.kt
+++ b/src/main/kotlin/objects/packets/objects/Passive.kt
@@ -1,0 +1,22 @@
+package objects.packets.objects
+
+import kotlinx.serialization.*
+import objects.*
+import objects.passives.*
+
+@Serializable
+enum class PassiveEffectType {
+    NONE,
+    DRAW_ON_DESTRUCTION,
+    BUFF_ADJACENT,
+}
+
+@Serializable
+data class Passive(
+    @Required var effect: PassiveEffectType = PassiveEffectType.NONE,
+    @Required var valueX: Int = 0,
+    @Required var valueY: Int = 0,
+)
+
+
+

--- a/src/main/kotlin/objects/passives/PassiveEffect.kt
+++ b/src/main/kotlin/objects/passives/PassiveEffect.kt
@@ -90,8 +90,7 @@ class BuffAdjacent(
         var atkIncrease = 0
         var hpIncrease = 0
         val stats: CardStats? = CardStats.getCardByID(card.state.id)
-        stats?.let {
-            cardStats ->
+        stats?.let { cardStats ->
             atkIncrease = stats.passive.values[0]
             hpIncrease = stats.passive.values[1]
         } ?: run {

--- a/src/main/kotlin/objects/passives/PassiveEffect.kt
+++ b/src/main/kotlin/objects/passives/PassiveEffect.kt
@@ -9,7 +9,7 @@ import objects.packets.*
 import objects.packets.objects.*
 import kotlin.math.max
 
-abstract class Passive(
+abstract class PassiveEffect(
     // The passive manager
     open val passiveManager: PassiveManager,
     // The card this passive belongs to.
@@ -35,22 +35,18 @@ class NullPassive(
     passiveManager: PassiveManager,
     card: Card,
     player: Player,
-) : Passive(passiveManager, card, player) {
+) : PassiveEffect(passiveManager, card, player) {
     override suspend fun update(
         lastChange: Packet?,
         boardState: BoardState,
     ): CardActionList? = null
 }
 
-/**
- *  Passive for 'Filipino Boy'
- *      Card holder draws card when destroyed
- */
-class FilipinoBoyPassive(
+class DrawOnDestruction(
     passiveManager: PassiveManager,
     card: Card,
     player: Player,
-) : Passive(passiveManager, card, player) {
+) : PassiveEffect(passiveManager, card, player) {
     private var drawRequestWasSent = false
 
     override suspend fun update(
@@ -74,11 +70,11 @@ class FilipinoBoyPassive(
     }
 }
 
-class AngelNeuroPassive(
+class BuffAdjacent(
     passiveManager: PassiveManager,
     card: Card,
     player: Player,
-) : Passive(passiveManager, card, player) {
+) : PassiveEffect(passiveManager, card, player) {
     private val adjacentCards: MutableMap<Card, Card> = mutableMapOf()
     private var removedBuffsOnDestroy = false
 
@@ -90,6 +86,18 @@ class AngelNeuroPassive(
         val addBuffList: MutableList<CardActionTarget> = mutableListOf()
         val actions: MutableList<CardAction> = mutableListOf()
 
+        // Assign values for atk and hp increase
+        var atkIncrease = 0
+        var hpIncrease = 0
+        val stats: CardStats? = CardStats.getCardByID(card.state.id)
+        stats?.let {
+            cardStats ->
+            atkIncrease = stats.passive.valueX
+            hpIncrease = stats.passive.valueY
+        } ?: run {
+            println("Warning: no card was found with ID ${card.state.id}")
+        }
+
         if (cardWasDestroyed()) {
             if (!removedBuffsOnDestroy) {
                 removedBuffsOnDestroy = true
@@ -100,8 +108,8 @@ class AngelNeuroPassive(
 
                 val removeBuffArray = removeBuffList.toTypedArray()
 
-                actions.add(CardAction(CardActionNames.SUB_ATTACK, removeBuffArray, 2))
-                actions.add(CardAction(CardActionNames.SUB_HP, removeBuffArray, 2, arrayOf(CardActionArgs.minHp(1))))
+                actions.add(CardAction(CardActionNames.SUB_ATTACK, removeBuffArray, atkIncrease))
+                actions.add(CardAction(CardActionNames.SUB_HP, removeBuffArray, hpIncrease, arrayOf(CardActionArgs.minHp(1))))
 
                 return CardActionList(card, actions.toTypedArray())
             }
@@ -120,8 +128,8 @@ class AngelNeuroPassive(
         for (c: Card in newAdjacentCards.values) {
             if (!adjacentCards.containsKey(c)) {
                 adjacentCards[c] = c
-                c.state.health += 2
-                c.state.attack_bonus += 2
+                c.state.health += atkIncrease
+                c.state.attack_bonus += hpIncrease
                 addBuffList.add(CardActionTarget(c.playerIdx, c.position))
             }
         }
@@ -137,8 +145,8 @@ class AngelNeuroPassive(
             if (cardWasDestroyed(c)) {
                 destroyedQueue.add(c)
             } else if (!newAdjacentCards.containsKey(c)) {
-                c.state.health = max(1, c.state.health - 2)
-                c.state.attack_bonus -= 2
+                c.state.health = max(1, c.state.health - hpIncrease)
+                c.state.attack_bonus -= atkIncrease
                 removeQueue.add(c)
             }
         }
@@ -150,18 +158,18 @@ class AngelNeuroPassive(
             removeBuffList.add(CardActionTarget(c.playerIdx, c.position))
         }
 
-        // Give new adjacentCards the +2 HP / +2 Attack Buff
+        // Give new adjacentCards the +x HP / +y Attack Buff
         if (addBuffList.isNotEmpty()) {
             val addBuffArray = addBuffList.toTypedArray()
-            actions.add(CardAction(CardActionNames.ADD_HP, addBuffArray, 2))
-            actions.add(CardAction(CardActionNames.ADD_ATTACK, addBuffArray, 2))
+            actions.add(CardAction(CardActionNames.ADD_HP, addBuffArray, hpIncrease))
+            actions.add(CardAction(CardActionNames.ADD_ATTACK, addBuffArray, atkIncrease))
         }
 
         // Remove buffs from cards no longer adjacent to angel
         if (removeBuffList.isNotEmpty()) {
             val removeBuffArray = removeBuffList.toTypedArray()
-            actions.add(CardAction(CardActionNames.SUB_ATTACK, removeBuffArray, 2))
-            actions.add(CardAction(CardActionNames.SUB_HP, removeBuffArray, 2, arrayOf(CardActionArgs.minHp(1))))
+            actions.add(CardAction(CardActionNames.SUB_ATTACK, removeBuffArray, hpIncrease))
+            actions.add(CardAction(CardActionNames.SUB_HP, removeBuffArray, atkIncrease, arrayOf(CardActionArgs.minHp(1))))
         }
 
         return CardActionList(card, actions.toTypedArray())

--- a/src/main/kotlin/objects/passives/PassiveEffect.kt
+++ b/src/main/kotlin/objects/passives/PassiveEffect.kt
@@ -92,8 +92,8 @@ class BuffAdjacent(
         val stats: CardStats? = CardStats.getCardByID(card.state.id)
         stats?.let {
             cardStats ->
-            atkIncrease = stats.passive.valueX
-            hpIncrease = stats.passive.valueY
+            atkIncrease = stats.passive.values[0]
+            hpIncrease = stats.passive.values[1]
         } ?: run {
             println("Warning: no card was found with ID ${card.state.id}")
         }

--- a/src/main/kotlin/objects/passives/PassiveManager.kt
+++ b/src/main/kotlin/objects/passives/PassiveManager.kt
@@ -16,7 +16,7 @@ class PassiveManager(
     // A Packet used to describe the last action that occurred.
     // Used to provide context when updating passives.
     var lastPacket: Packet? = null
-    val passives: HashMap<Card, Passive> = hashMapOf()
+    val passives: HashMap<Card, PassiveEffect> = hashMapOf()
 
     fun playerToIdx(player: Player): Int {
         if (player == Player.Player1) {
@@ -39,12 +39,12 @@ class PassiveManager(
         card: Card,
         player: Player,
     ) {
-        val newPassive: Passive? = assignPassiveByCard(card, player)
+        val newPassive: PassiveEffect? = assignPassiveByCard(card, player)
         when (newPassive) {
             is NullPassive -> {
                 // Ignore
             }
-            is Passive -> {
+            is PassiveEffect -> {
                 println("adding new passive: $newPassive")
                 passives[card] = newPassive
             }
@@ -60,18 +60,18 @@ class PassiveManager(
     fun assignPassiveByCard(
         card: Card,
         player: Player,
-    ): Passive? {
+    ): PassiveEffect? {
         println("Card's ID is ${card.state.id}")
-        when (card.state.id) {
+        when (CardStats.getCardByID(card.state.id)?.passive?.effect) {
             // TODO: Create Unique passives for each card.
-            CardIDNumbers.PIRATE_EVIL -> {
+            PassiveEffectType.NONE -> {
                 return NullPassive(this, card, player)
             }
-            CardIDNumbers.ANGEL_NEURO -> {
-                return AngelNeuroPassive(this, card, player)
+            PassiveEffectType.BUFF_ADJACENT -> {
+                return BuffAdjacent(this, card, player)
             }
-            CardIDNumbers.FILIPINO_BOY -> {
-                return FilipinoBoyPassive(this, card, player)
+            PassiveEffectType.DRAW_ON_DESTRUCTION -> {
+                return DrawOnDestruction(this, card, player)
             }
             else -> {
                 return null
@@ -89,7 +89,7 @@ class PassiveManager(
 
         println("Updating ${passives.size} passives...")
 
-        for (p: Passive in passives.values) {
+        for (p: PassiveEffect in passives.values) {
             val updates: CardActionList? = p.update(lastPacket, boardManager.getBoardState())
 
             if (updates == null) {


### PR DESCRIPTION
Did some refractoring to make passives more general and allow them to be easily added from CardStats like all the other card properites. 

Chages: 
The existing Passive class has been renamed as **PassiveEffect** 
A new serializable class **Passive** allows configuring different passives in CardStats. 
two properties **valueX** and **valueY** can be used to configure passives with differing values but same functionality. 
the property **effect** stores a PassiveEffectType which is what is now used by the **assignPassiveByCard** function to assign passives to cards. 